### PR TITLE
Prep OSSC: first script; use local dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Systems tested:
 
 ### Contents of directories
 - `cbs/` contains a README I sent along the model upload
-- `della-scripts` and `snellius-scripts` contain scripts for running code on the respective systems
+- `della-scripts`, `snellius-scripts` and `ossc-scripts` contain scripts for running code on the respective systems. They also have READMEs describing details for running the scripts
 - `plots/` contains some code from Matt for comparing the runs across systems
 - `requirements/` contains files related to managing dependencies
 -  `configs/` contains configuration files for torchtune.
+- `datasets/` contains training datasets.
+    - `alpaca_data_cleaned.json` contains text that is fed to the model for updating the parameters.

--- a/ossc-scripts/README.md
+++ b/ossc-scripts/README.md
@@ -1,0 +1,15 @@
+
+## Running on the OSSC
+
+Use local datasets and store them in `datasets/`. Ideally use text-based file formats such as json for easier inspection by CBS.
+- The file `alpaca_data_cleaned.json` was downloaded from https://huggingface.co/datasets/yahma/alpaca-cleaned/tree/main on 27/01/2025.
+
+## Getting code to OSSC
+
+1. Make release on GitHub 
+2. Import code via CBS upload/download portal
+    - Make sure the code can work with local datasets.
+3. Ask SURF to install dependencies
+
+
+

--- a/ossc-scripts/a100_1device.slurm
+++ b/ossc-scripts/a100_1device.slurm
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+#SBATCH --job-name=a100_1device
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=18
+#SBATCH --time=15:00
+#SBATCH --mem=80G
+#SBATCH -p gpu_a100
+#SBATCH --gpus 1
+#SBATCH -e logs/%x-%j.err
+#SBATCH -o logs/%x-%j.out
+
+source requirements/load_venv.sh
+source snellius-scripts/setup.sh
+
+tune run \
+    lora_finetune_single_device \
+    --config configs/1B_lora_single_device.yaml \
+    max_steps_per_epoch=$MAX_STEPS \
+    checkpointer.checkpoint_dir=$MODEL_DIR \
+    tokenizer.path=$MODEL_DIR/original/tokenizer.model \
+    checkpointer.output_dir=$OUTPUT_DIR \
+    metric_logger.log_dir=$OUTPUT_DIR \
+    metric_logger.name=$WANDB_NAME \
+    metric_logger.id=$WANDB_NAME \
+    batch_size=$BATCH_SIZE \
+    dataset.data_files="datasets/alpaca_data_cleaned.json" \
+    dataset.source="json"
+
+


### PR DESCRIPTION
Make it possible to run with local data
- add alpaca json dataset 
- override dataset configs in ossc-scripts

On a single run on Snellius, I have not noticed a substantial speed difference between using the local dataset and the default (download from HF).