### PR TITLE
Ossc runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ Systems tested:
 - `datasets/` contains training datasets.
     - `alpaca_data_cleaned.json` contains text that is fed to the model for updating the parameters.
     - The dataset is licensed under `datasets/LICENSE`, while the remaining code in this repository falls under `./LICENSE`.
+
+
+### Performance results
+
+| Batch Size 6 Comparison On: | Della | Snellius | OSSC  |
+|:---------------------------:|:-----:|:--------:|:-----:|
+|            1 A100           | 19422 |   17500  | 17700 | 
+|           2 A100s           | 18247 |   16500  | 16500 |
+|           4 A100s           | 18019 |   16400  | 16400 |
+|            1 H100           | 36668 |   31100  | 31000 |
+|           2 H100s           | 34228 |   28800  | 28600 |
+|           4 H100s           | 33650 |   28600  | 28500 |

--- a/ossc-scripts/a100_1device.slurm
+++ b/ossc-scripts/a100_1device.slurm
@@ -6,13 +6,14 @@
 #SBATCH --cpus-per-task=18
 #SBATCH --time=15:00
 #SBATCH --mem=80G
-#SBATCH -p gpu_a100
-#SBATCH --gpus 1
+#SBATCH -p comp_env
 #SBATCH -e logs/%x-%j.err
 #SBATCH -o logs/%x-%j.out
 
 source requirements/load_venv.sh
 source snellius-scripts/setup.sh
+
+export CUDA_VISIBLE_DEVICES=0
 
 tune run \
     lora_finetune_single_device \

--- a/ossc-scripts/a100_2device.slurm
+++ b/ossc-scripts/a100_2device.slurm
@@ -6,13 +6,14 @@
 #SBATCH --cpus-per-task=18
 #SBATCH --time=15:00
 #SBATCH --mem=80G
-#SBATCH -p gpu_a100
-#SBATCH --gpus 2
+#SBATCH -p comp_env
 #SBATCH -e logs/%x-%j.err
 #SBATCH -o logs/%x-%j.out
 
 source requirements/load_venv.sh
 source snellius-scripts/setup.sh
+
+export CUDA_VISIBLE_DEVICES=0,1
 
 tune run \
     --nproc_per_node=$SLURM_GPUS \

--- a/ossc-scripts/a100_4device.slurm
+++ b/ossc-scripts/a100_4device.slurm
@@ -1,18 +1,19 @@
 #!/bin/bash
 #
-#SBATCH --job-name=a100_2device
+#SBATCH --job-name=a100_4device
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=18
 #SBATCH --time=15:00
 #SBATCH --mem=80G
-#SBATCH -p gpu_a100
-#SBATCH --gpus 2
+#SBATCH -p comp_env
 #SBATCH -e logs/%x-%j.err
 #SBATCH -o logs/%x-%j.out
 
 source requirements/load_venv.sh
 source snellius-scripts/setup.sh
+
+export CUDA_VISIBLE_DEVICES=0,1,2,3
 
 tune run \
     --nproc_per_node=$SLURM_GPUS \

--- a/ossc-scripts/h100_1device.slurm
+++ b/ossc-scripts/h100_1device.slurm
@@ -1,24 +1,22 @@
 #!/bin/bash
 #
-#SBATCH --job-name=a100_2device
+#SBATCH --job-name=h100_1device
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=18
 #SBATCH --time=15:00
 #SBATCH --mem=80G
-#SBATCH -p gpu_a100
-#SBATCH --gpus 2
+#SBATCH -p comp_env
 #SBATCH -e logs/%x-%j.err
 #SBATCH -o logs/%x-%j.out
 
 source requirements/load_venv.sh
 source snellius-scripts/setup.sh
 
+export CUDA_VISIBLE_DEVICES=0
 tune run \
-    --nproc_per_node=$SLURM_GPUS \
-    --nnodes=$SLURM_JOB_NUM_NODES \
-    lora_finetune_distributed \
-    --config configs/1B_lora_distributed.yaml \
+    lora_finetune_single_device \
+    --config configs/1B_lora_single_device.yaml \
     max_steps_per_epoch=$MAX_STEPS \
     checkpointer.checkpoint_dir=$MODEL_DIR \
     tokenizer.path=$MODEL_DIR/original/tokenizer.model \
@@ -29,4 +27,5 @@ tune run \
     batch_size=$BATCH_SIZE \
     dataset.data_files="datasets/alpaca_data_cleaned.json" \
     dataset.source="json"
+
 

--- a/ossc-scripts/h100_2device.slurm
+++ b/ossc-scripts/h100_2device.slurm
@@ -1,19 +1,19 @@
 #!/bin/bash
 #
-#SBATCH --job-name=a100_2device
+#SBATCH --job-name=h100_2device
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=18
 #SBATCH --time=15:00
 #SBATCH --mem=80G
-#SBATCH -p gpu_a100
-#SBATCH --gpus 2
+#SBATCH -p comp_env
 #SBATCH -e logs/%x-%j.err
 #SBATCH -o logs/%x-%j.out
 
 source requirements/load_venv.sh
 source snellius-scripts/setup.sh
 
+export CUDA_VISIBLE_DEVICES=0,1
 tune run \
     --nproc_per_node=$SLURM_GPUS \
     --nnodes=$SLURM_JOB_NUM_NODES \

--- a/ossc-scripts/h100_4device.slurm
+++ b/ossc-scripts/h100_4device.slurm
@@ -1,18 +1,18 @@
 #!/bin/bash
 #
-#SBATCH --job-name=a100_2device
+#SBATCH --job-name=h100_4device
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=18
 #SBATCH --time=15:00
 #SBATCH --mem=80G
-#SBATCH -p gpu_a100
-#SBATCH --gpus 2
+#SBATCH -p comp_env
 #SBATCH -e logs/%x-%j.err
 #SBATCH -o logs/%x-%j.out
 
 source requirements/load_venv.sh
 source snellius-scripts/setup.sh
+export CUDA_VISIBLE_DEVICES=0,1,2,3
 
 tune run \
     --nproc_per_node=$SLURM_GPUS \
@@ -29,4 +29,5 @@ tune run \
     batch_size=$BATCH_SIZE \
     dataset.data_files="datasets/alpaca_data_cleaned.json" \
     dataset.source="json"
+
 

--- a/snellius-scripts/a100_1device.slurm
+++ b/snellius-scripts/a100_1device.slurm
@@ -24,6 +24,7 @@ tune run \
     metric_logger.log_dir=$OUTPUT_DIR \
     metric_logger.name=$WANDB_NAME \
     metric_logger.id=$WANDB_NAME \
-    batch_size=$BATCH_SIZE
-
+    batch_size=$BATCH_SIZE \
+    dataset.data_files="datasets/alpaca_data_cleaned.json" \
+    dataset.source="json"
 

--- a/snellius-scripts/a100_4device.slurm
+++ b/snellius-scripts/a100_4device.slurm
@@ -26,6 +26,8 @@ tune run \
     metric_logger.log_dir=$OUTPUT_DIR \
     metric_logger.name=$WANDB_NAME \
     metric_logger.id=$WANDB_NAME \
-    batch_size=$BATCH_SIZE
+    batch_size=$BATCH_SIZE \
+    dataset.data_files="datasets/alpaca_data_cleaned.json" \
+    dataset.source="json"
 
 

--- a/snellius-scripts/h100_1device.slurm
+++ b/snellius-scripts/h100_1device.slurm
@@ -24,6 +24,8 @@ tune run \
     metric_logger.log_dir=$OUTPUT_DIR \
     metric_logger.name=$WANDB_NAME \
     metric_logger.id=$WANDB_NAME \
-    batch_size=$BATCH_SIZE
+    batch_size=$BATCH_SIZE \
+    dataset.data_files="datasets/alpaca_data_cleaned.json" \
+    dataset.source="json"
 
 

--- a/snellius-scripts/h100_2device.slurm
+++ b/snellius-scripts/h100_2device.slurm
@@ -26,6 +26,8 @@ tune run \
     metric_logger.log_dir=$OUTPUT_DIR \
     metric_logger.name=$WANDB_NAME \
     metric_logger.id=$WANDB_NAME \
-    batch_size=$BATCH_SIZE
+    batch_size=$BATCH_SIZE \
+    dataset.data_files="datasets/alpaca_data_cleaned.json" \
+    dataset.source="json"
 
 

--- a/snellius-scripts/setup.sh
+++ b/snellius-scripts/setup.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
+export RDZV_HOST=$(hostname)
+export RDZV_PORT=29400
+
+echo "Running on host: $RDZV_HOST"
 
 MAX_STEPS=512 # 128 for testing, 512 for benchmarking
 BATCH_SIZE=6
 
 MODEL_NAME="Llama-3-2-1b-Instruct"
-DATA_ROOT="/projects/0/prjs1019/torchtune"
+
+if [[ $RDZV_HOST == *"ossc"* ]]; then
+    DATA_ROOT="/gpfs/ostor/ossc9424/homedir/torchtune/"
+else
+    DATA_ROOT="/projects/0/prjs1019/torchtune"
+fi
 
 MODEL_DIR="${DATA_ROOT}/models/${MODEL_NAME}"
 OUTPUT_DIR="${DATA_ROOT}/outputs/${MODEL_NAME}"
@@ -18,9 +27,5 @@ fi
 WANDB_NAME=$SLURM_JOB_NAME
 
 
-export RDZV_HOST=$(hostname)
-export RDZV_PORT=29400
-
-echo "Running on host:: $RDZV_HOST"
 
 


### PR DESCRIPTION
- Add slurm scripts from OSSC runs this week
- use local datasets in all snellius/ossc scripts 
- dynamically assign data root depending on ossc vs snellius
- udpate README with perf numbers